### PR TITLE
change container template

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,14 +402,9 @@ ports:
 
 game-server-details:
   executable-file-path: ./MyGame/my-server-executable           # Entry point to execute the game server
-  game-server-args:                                             # (Optional) Argument key value pairs that are passed to the game server entry point
-    - arg: "--port"
-      val: "{{.GamePort}}"
-      pos: 0
 ```
 
 - Provide the path of your game server executable in `executable-file-path`. Using the above config as an example the wrapper would expect the game server to be on disk at `./gameserver.sh`
-- `game-server-args` defines arguments that will be passed to the game server executable. See [Game Server Arguments](#game-server-arguments) for details.
 
 ### Build Image
 Build the image using `docker build` for the gamelift-servers-managed-containers directory. For example

--- a/src/template/template-managed-containers-config.yaml
+++ b/src/template/template-managed-containers-config.yaml
@@ -9,7 +9,3 @@ ports:
 
 game-server-details:
   executable-file-path: ./MyGame/my-server-executable
-  game-server-args:
-    - arg: "--port"
-      val: "{{.GamePort}}"
-      pos: 0


### PR DESCRIPTION
In managed container fleet scenario:
The wrapper will report the connection port to GameLift. However, the port mapping relationship still connects the host's connection port to the container port (defined when configuring the container group). The wrapper should not pass this connection port to the server application, as this would force the server to modify its listening port configuration.