### PR TITLE
Merge version 1.0.1 changes to amazon-gamelift/main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ COMPUTE_TYPES ?= managed-ec2 anywhere managed-containers
 
 MAJOR ?= 1
 MINOR ?= 0
-PATCH ?= 0
+PATCH ?= 1
 APP_NAME ?= amazon-gamelift-servers-game-server-wrapper
 APP_PACKAGE ?= github.com/amazon-gamelift/$(APP_NAME)
-SERVER_SDK_URL=https://gamelift-server-sdk-release.s3.us-west-2.amazonaws.com/go/GameLift-Go-ServerSDK-5.2.1.zip
+SERVER_SDK_URL=https://github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/releases/download/v5.3.0/GameLift-Go-ServerSDK-5.3.0.zip
 SERVER_SDK_FILE_NAME=gamelift-servers-server-sdk.zip
 SERVER_SDK_EXTRACT_DIR=src/ext/gamelift-servers-server-sdk
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ aws gamelift upload-build \
     --build-version gamelift-test-2025-03-11-1 \
     --build-root out/linux/amd64/gamelift-servers-managed-ec2 \
     --operating-system AMAZON_LINUX_2023 \
-    --server-sdk-version 5.2.1 \
+    --server-sdk-version 5.3.0 \
     --region us-west-2
 ```
 - For Windows builds, use `--operating-system WINDOWS_2016`
@@ -404,7 +404,7 @@ game-server-details:
   executable-file-path: ./MyGame/my-server-executable           # Entry point to execute the game server
   game-server-args:                                             # (Optional) Argument key value pairs that are passed to the game server entry point
     - arg: "--port"
-      val: "{{.GamePort}}"
+      val: "{{.ContainerPort}}"                                 # This is the container-internal port that your game server listens on. The value comes from the 'ports: gamePort' setting.
       pos: 0
 ```
 
@@ -446,7 +446,7 @@ aws gamelift create-container-group-definition \
 --operating-system AMAZON_LINUX_2023 \
 --total-memory-limit-mebibytes 1024 \
 --total-vcpu-limit 1 \
---game-server-container-definition "{\"ContainerName\": \"GameServer\", \"ImageUri\": \"${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/gamelift-sdk-wrapper-sample:latest\", \"PortConfiguration\": {\"ContainerPortRanges\": [{\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"TCP\"}]}, \"ServerSdkVersion\": \"5.2.1\"}"
+--game-server-container-definition "{\"ContainerName\": \"GameServer\", \"ImageUri\": \"${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/gamelift-sdk-wrapper-sample:latest\", \"PortConfiguration\": {\"ContainerPortRanges\": [{\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"TCP\"}]}, \"ServerSdkVersion\": \"5.3.0\"}"
 ```
 Wait for it to be READY before proceeding. You can check its status using [AWS console](https://console.aws.amazon.com/gamelift/container-groups) or [DescribeContainerGroupDefinition API](https://docs.aws.amazon.com/gamelift/latest/apireference/API_DescribeContainerGroupDefinition.html)
 ### Create Container Fleet Role

--- a/build.ps1
+++ b/build.ps1
@@ -4,7 +4,7 @@
 param (
     [string]$Major = "1",
     [string]$Minor = "0",
-    [string]$Patch = "0",
+    [string]$Patch = "1",
     [string]$Out = "out"
 )
 
@@ -16,7 +16,7 @@ $GoArch = "amd64"
 $FileExt = ".exe"
 $OutFolder = "$Out\$GoOS\$GoArch\"
 $BuildDir = "src"
-$ServerSdkUrl = "https://gamelift-server-sdk-release.s3.us-west-2.amazonaws.com/go/GameLift-Go-ServerSDK-5.2.1.zip"
+$ServerSdkUrl = "https://github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/releases/download/v5.3.0/GameLift-Go-ServerSDK-5.3.0.zip"
 $ServerSdkFileName = "gamelift-server-sdk.zip"
 $ServerSdkExtractDir = "src/ext/gamelift-servers-server-sdk"
 

--- a/src/cmd/app-init.go
+++ b/src/cmd/app-init.go
@@ -6,11 +6,12 @@
 package cmd
 
 import (
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
-	"github.com/spf13/cobra"
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
+	"github.com/spf13/cobra"
 )
 
 // appInit initializes the application's core components including logging

--- a/src/cmd/flag-types.go
+++ b/src/cmd/flag-types.go
@@ -6,8 +6,9 @@
 package cmd
 
 import (
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"time"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 )
 
 type hostingProvider config.Provider

--- a/src/cmd/pre-run.go
+++ b/src/cmd/pre-run.go
@@ -6,15 +6,16 @@
 package cmd
 
 import (
+	"io"
+	"log/slog"
+	"os"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/logging"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"io"
-	"log/slog"
-	"os"
 )
 
 func preRun(cmd *cobra.Command, args []string) error {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -8,12 +8,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/config"

--- a/src/cmd/version.go
+++ b/src/cmd/version.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal"
 	"github.com/spf13/cobra"
 )

--- a/src/go.mod
+++ b/src/go.mod
@@ -2,10 +2,10 @@ module github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper
 
 go 1.22.1
 
-replace aws/amazon-gamelift-go-sdk => ./ext/gamelift-servers-server-sdk
+replace github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk => ./ext/gamelift-servers-server-sdk
 
 require (
-	aws/amazon-gamelift-go-sdk v0.0.0-00010101000000-000000000000
+	github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk v0.0.0-20250527005813-7edcfc53c706
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.9
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.9

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -7,12 +7,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
-	"github.com/go-playground/validator/v10"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/go-playground/validator/v10"
 
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"

--- a/src/internal/mocks/mocks.go
+++ b/src/internal/mocks/mocks.go
@@ -6,8 +6,8 @@
 package mocks
 
 import (
-	"aws/amazon-gamelift-go-sdk/server"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/process"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/context"

--- a/src/internal/multiplexgame/multiplexgame.go
+++ b/src/internal/multiplexgame/multiplexgame.go
@@ -9,6 +9,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/multiplexgame/args"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
@@ -16,9 +20,6 @@ import (
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/process"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
-	"io"
-	"log/slog"
-	"os"
 )
 
 // New creates a new MultiplexGame instance with the provided configuration and dependencies.

--- a/src/internal/multiplexgame/multiplexgame_test.go
+++ b/src/internal/multiplexgame/multiplexgame_test.go
@@ -7,6 +7,12 @@ package multiplexgame
 
 import (
 	"bytes"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
@@ -17,11 +23,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"log/slog"
-	"path/filepath"
-	"runtime"
-	"testing"
-	"time"
 )
 
 type MultiPlexGameMock struct {

--- a/src/internal/services/hosting.go
+++ b/src/internal/services/hosting.go
@@ -7,9 +7,10 @@ package services
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/initialiser"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
-	"log/slog"
 
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting"

--- a/src/internal/services/services.go
+++ b/src/internal/services/services.go
@@ -8,8 +8,9 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/runner"
 	"log/slog"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/runner"
 
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/logging"

--- a/src/internal/testing/mocks/gl.go
+++ b/src/internal/testing/mocks/gl.go
@@ -6,9 +6,10 @@
 package mocks
 
 import (
-	"aws/amazon-gamelift-go-sdk/server"
 	"runtime"
 	"strings"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server"
 )
 
 type GlMock struct {

--- a/src/pkg/app/app.go
+++ b/src/pkg/app/app.go
@@ -7,20 +7,21 @@ package app
 
 import (
 	"context"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/runner"
 	"github.com/pkg/errors"
-	"log/slog"
-	"runtime/debug"
-	"time"
 )
 
 // Service represents the application service that manages the game server lifecycle
 type Service struct {
-	logger  *slog.Logger			// Handles logging operations
-	runner  *runner.Runner			// Manages game server execution
-	spanner observability.Spanner	// Provides tracing and monitoring
+	logger  *slog.Logger          // Handles logging operations
+	runner  *runner.Runner        // Manages game server execution
+	spanner observability.Spanner // Provides tracing and monitoring
 }
 
 // Run executes the application logic with panic recovery and observability.

--- a/src/pkg/app/app_test.go
+++ b/src/pkg/app/app_test.go
@@ -7,6 +7,10 @@ package app
 
 import (
 	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
@@ -14,9 +18,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"log/slog"
-	"testing"
-	"time"
 )
 
 type AppMock struct {

--- a/src/pkg/config/config.go
+++ b/src/pkg/config/config.go
@@ -60,11 +60,11 @@ const (
 
 // AwsConfig defines the configuration for AWS service access.
 type AwsConfig struct {
-	Region  string           `mapstructure:"region" yaml:"region,omitempty"`
+	Region   string            `mapstructure:"region" yaml:"region,omitempty"`
 	Provider AwsConfigProvider `mapstructure:"provider" yaml:"provider,omitempty"`
-	Literal AwsConfigLiteral `mapstructure:"literal" yaml:"literal,omitempty"`
-	Profile string           `mapstructure:"profile" yaml:"profile,omitempty"`
-	SSOFile string           `mapstructure:"ssoFile" yaml:"ssoFile,omitempty"`
+	Literal  AwsConfigLiteral  `mapstructure:"literal" yaml:"literal,omitempty"`
+	Profile  string            `mapstructure:"profile" yaml:"profile,omitempty"`
+	SSOFile  string            `mapstructure:"ssoFile" yaml:"ssoFile,omitempty"`
 }
 
 // AwsConfigLiteral contains direct AWS credentials.

--- a/src/pkg/game/game.go
+++ b/src/pkg/game/game.go
@@ -7,6 +7,7 @@ package game
 
 import (
 	"context"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
 	"github.com/google/uuid"
 )

--- a/src/pkg/hosting/gamelift/client/profile.go
+++ b/src/pkg/hosting/gamelift/client/profile.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/pkg/errors"
 )

--- a/src/pkg/hosting/gamelift/client/provider.go
+++ b/src/pkg/hosting/gamelift/client/provider.go
@@ -8,13 +8,14 @@ package client
 import (
 	"context"
 	"fmt"
+	"log/slog"
+
 	pkgConfig "github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	gl "github.com/aws/aws-sdk-go-v2/service/gamelift"
 	"github.com/aws/smithy-go/logging"
 	"github.com/pkg/errors"
-	"log/slog"
 )
 
 var _ Provider = (*provider)(nil)
@@ -80,25 +81,25 @@ func (provider *provider) GetGameLift(ctx context.Context) (GameLift, error) {
 }
 
 func NewProvider(cfg pkgConfig.Anywhere, logger *slog.Logger) (Provider, error) {
-    var configProvider ConfigProvider
+	var configProvider ConfigProvider
 	if len(cfg.Config.Region) == 0 {
 		return nil, errors.New("no region specified")
 	}
 
-    switch cfg.Config.Provider {
-    case pkgConfig.AwsConfigProviderProfile:
-        configProvider = NewProfileProvider(cfg.Config.Profile)
-    case pkgConfig.AwsConfigProviderSSOFile:
-        if len(cfg.Config.SSOFile) == 0 {
-            return nil, fmt.Errorf("no sso env file path provided")
-        }
-        configProvider = NewSSOFileProvider(cfg.Config.SSOFile, logger)
-    default:
-        return nil, fmt.Errorf("unknown provider: %s", cfg.Config.Provider)
-    }
+	switch cfg.Config.Provider {
+	case pkgConfig.AwsConfigProviderProfile:
+		configProvider = NewProfileProvider(cfg.Config.Profile)
+	case pkgConfig.AwsConfigProviderSSOFile:
+		if len(cfg.Config.SSOFile) == 0 {
+			return nil, fmt.Errorf("no sso env file path provided")
+		}
+		configProvider = NewSSOFileProvider(cfg.Config.SSOFile, logger)
+	default:
+		return nil, fmt.Errorf("unknown provider: %s", cfg.Config.Provider)
+	}
 
 	p := &provider{
-	    optProvider: configProvider,
+		optProvider: configProvider,
 		cfg:         cfg,
 		logger:      logger,
 	}

--- a/src/pkg/hosting/gamelift/client/shim.go
+++ b/src/pkg/hosting/gamelift/client/shim.go
@@ -7,6 +7,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 )
 

--- a/src/pkg/hosting/gamelift/client/sso-file.go
+++ b/src/pkg/hosting/gamelift/client/sso-file.go
@@ -7,6 +7,11 @@ package client
 
 import (
 	"context"
+	"log/slog"
+	"reflect"
+	"strings"
+	"sync"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
@@ -14,10 +19,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"log/slog"
-	"reflect"
-	"strings"
-	"sync"
 )
 
 var _ ConfigProvider = (*SSOFileProvider)(nil)

--- a/src/pkg/hosting/gamelift/gamelift.go
+++ b/src/pkg/hosting/gamelift/gamelift.go
@@ -6,19 +6,20 @@
 package gamelift
 
 import (
-	"aws/amazon-gamelift-go-sdk/model"
-	"aws/amazon-gamelift-go-sdk/server"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"log/slog"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/model"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server"
 
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting"
@@ -266,6 +267,10 @@ func (gameLift *gamelift) glOnStartGameSession(gs model.GameSession) {
 		MatchmakerData:            gs.MatchmakerData,
 		MaximumPlayerSessionCount: gs.MaximumPlayerSessionCount,
 		Provider:                  config.ProviderGameLift,
+	}
+
+	if strings.HasPrefix(hse.FleetId, "containerfleet-") {
+		hse.ContainerPort = gameLift.cfg.GamePort
 	}
 
 	if err := gameLift.sdk.ActivateGameSession(gameLift.ctx); err != nil {

--- a/src/pkg/hosting/gamelift/initialiser/anywhere.go
+++ b/src/pkg/hosting/gamelift/initialiser/anywhere.go
@@ -6,19 +6,20 @@
 package initialiser
 
 import (
-	"aws/amazon-gamelift-go-sdk/common"
-	"aws/amazon-gamelift-go-sdk/server"
 	"context"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/client"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
-	"github.com/aws/aws-sdk-go-v2/service/gamelift"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"log/slog"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/client"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/common"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server"
+	"github.com/aws/aws-sdk-go-v2/service/gamelift"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 )
 
 type anywhere struct {

--- a/src/pkg/hosting/gamelift/initialiser/anywhere_test.go
+++ b/src/pkg/hosting/gamelift/initialiser/anywhere_test.go
@@ -9,6 +9,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/client"
@@ -16,9 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/gamelift/types"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/stretchr/testify/assert"
-	"log/slog"
-	"testing"
-	"time"
 )
 
 type AnywhereMockHelper struct {

--- a/src/pkg/hosting/gamelift/initialiser/initialiser_test.go
+++ b/src/pkg/hosting/gamelift/initialiser/initialiser_test.go
@@ -7,15 +7,16 @@ package initialiser
 
 import (
 	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/client"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"log/slog"
-	"testing"
-	"time"
 )
 
 type InitialiserMockHelper struct {
@@ -78,11 +79,11 @@ func Test_GetService_HappyPath_Anywhere(t *testing.T) {
 
 	anywhereConfig := config.Anywhere{
 		Config: config.AwsConfig{
-			Region:  "eu-west-1",
+			Region:   "eu-west-1",
 			Provider: "aws-profile",
-			Literal: config.AwsConfigLiteral{},
-			Profile: "gamelift",
-			SSOFile: "",
+			Literal:  config.AwsConfigLiteral{},
+			Profile:  "gamelift",
+			SSOFile:  "",
 		},
 		Host: config.AnywhereHostConfig{
 			HostName:    "gamelift",

--- a/src/pkg/hosting/gamelift/initialiser/managed.go
+++ b/src/pkg/hosting/gamelift/initialiser/managed.go
@@ -6,11 +6,12 @@
 package initialiser
 
 import (
-	"aws/amazon-gamelift-go-sdk/server"
 	"context"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
 	"log/slog"
 	"sync"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server"
 )
 
 type managed struct {

--- a/src/pkg/hosting/gamelift/initialiser/managed_test.go
+++ b/src/pkg/hosting/gamelift/initialiser/managed_test.go
@@ -7,18 +7,19 @@ package initialiser
 
 import (
 	"bytes"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
-	"golang.org/x/net/context"
 	"log/slog"
 	"time"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
+	"golang.org/x/net/context"
 )
 
 type ManagedMockHelper struct {
-	logger            *slog.Logger
-	logBuffer         *bytes.Buffer
-	gameLiftSdk       *mocks.GameLiftSdkMock
-	ctx               context.Context
-	managed           Service
+	logger      *slog.Logger
+	logBuffer   *bytes.Buffer
+	gameLiftSdk *mocks.GameLiftSdkMock
+	ctx         context.Context
+	managed     Service
 }
 
 func createManagedMockHelper() ManagedMockHelper {
@@ -30,12 +31,10 @@ func createManagedMockHelper() ManagedMockHelper {
 	gameLiftSdkMock := mocks.GameLiftSdkMock{}
 	managed := newManaged(&gameLiftSdkMock, logger)
 	return ManagedMockHelper{
-		logger:            logger,
-		logBuffer:         &logBuffer,
-		gameLiftSdk:       &gameLiftSdkMock,
-		ctx:               ctx,
-		managed:           managed,
+		logger:      logger,
+		logBuffer:   &logBuffer,
+		gameLiftSdk: &gameLiftSdkMock,
+		ctx:         ctx,
+		managed:     managed,
 	}
 }
-
-

--- a/src/pkg/hosting/gamelift/initialiser/mocks.go
+++ b/src/pkg/hosting/gamelift/initialiser/mocks.go
@@ -6,10 +6,11 @@
 package initialiser
 
 import (
+	"log/slog"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/config"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting/gamelift/sdk"
 	"golang.org/x/net/context"
-	"log/slog"
 )
 
 type InitialiserServiceMock struct {

--- a/src/pkg/hosting/gamelift/platform/platform_darwin.go
+++ b/src/pkg/hosting/gamelift/platform/platform_darwin.go
@@ -1,9 +1,9 @@
+//go:build darwin
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-//go:build darwin
 
 package platform
 

--- a/src/pkg/hosting/gamelift/platform/platform_linux.go
+++ b/src/pkg/hosting/gamelift/platform/platform_linux.go
@@ -1,9 +1,9 @@
+//go:build linux
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-//go:build linux
 
 package platform
 

--- a/src/pkg/hosting/gamelift/platform/platform_windows.go
+++ b/src/pkg/hosting/gamelift/platform/platform_windows.go
@@ -1,9 +1,9 @@
+//go:build windows
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-//go:build windows
 
 package platform
 

--- a/src/pkg/hosting/gamelift/sdk/logging.go
+++ b/src/pkg/hosting/gamelift/sdk/logging.go
@@ -6,11 +6,12 @@
 package sdk
 
 import (
-	"aws/amazon-gamelift-go-sdk/server/log"
 	"context"
 	"fmt"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"log/slog"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server/log"
 )
 
 type logAdaptor struct {

--- a/src/pkg/hosting/gamelift/sdk/sdk.go
+++ b/src/pkg/hosting/gamelift/sdk/sdk.go
@@ -6,9 +6,10 @@
 package sdk
 
 import (
-	"aws/amazon-gamelift-go-sdk/server"
 	"context"
 	"log/slog"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/server"
 )
 
 // GameLiftSdk defines the interface for interacting with server SDK for Amazon GameLift Servers.

--- a/src/pkg/hosting/hosting.go
+++ b/src/pkg/hosting/hosting.go
@@ -7,9 +7,10 @@ package hosting
 
 import (
 	"context"
+	"net/netip"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
 	"github.com/google/uuid"
-	"net/netip"
 )
 
 // IpAddresses contains the network addressing information for a hosting option.

--- a/src/pkg/hosting/mocks.go
+++ b/src/pkg/hosting/mocks.go
@@ -6,9 +6,10 @@
 package hosting
 
 import (
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
 	"golang.org/x/net/context"
-	"time"
 )
 
 type HostingServiceMock struct {

--- a/src/pkg/logging/buffered-logger.go
+++ b/src/pkg/logging/buffered-logger.go
@@ -9,12 +9,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
-	"github.com/pkg/errors"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
+	"github.com/pkg/errors"
 )
 
 type BufferedLogger struct {

--- a/src/pkg/logging/buffered-logger_test.go
+++ b/src/pkg/logging/buffered-logger_test.go
@@ -9,12 +9,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"log/slog"
 	"os"
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type msg struct {

--- a/src/pkg/logging/context-handler.go
+++ b/src/pkg/logging/context-handler.go
@@ -7,8 +7,9 @@ package logging
 
 import (
 	"context"
-	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"log/slog"
+
+	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 )
 
 type ContextHandler struct {

--- a/src/pkg/manager/harness.go
+++ b/src/pkg/manager/harness.go
@@ -7,13 +7,14 @@ package manager
 
 import (
 	"context"
+	"log/slog"
+	"strings"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"log/slog"
-	"strings"
 )
 
 // Harness defines the interface for game server lifecycle management.

--- a/src/pkg/manager/harness_test.go
+++ b/src/pkg/manager/harness_test.go
@@ -8,6 +8,10 @@ package manager
 import (
 	"bytes"
 	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
@@ -15,9 +19,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"log/slog"
-	"testing"
-	"time"
 )
 
 type HarnessTestHelper struct {

--- a/src/pkg/manager/manager.go
+++ b/src/pkg/manager/manager.go
@@ -7,13 +7,14 @@ package manager
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"log/slog"
 )
 
 // Service defines the interface for managing the complete lifecycle of a game server.

--- a/src/pkg/manager/manager_test.go
+++ b/src/pkg/manager/manager_test.go
@@ -8,6 +8,10 @@ package manager
 import (
 	"bytes"
 	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/hosting"
@@ -16,9 +20,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"log/slog"
-	"testing"
-	"time"
 )
 
 type ManagerTestHelper struct {

--- a/src/pkg/manager/mocks.go
+++ b/src/pkg/manager/mocks.go
@@ -6,10 +6,11 @@
 package manager
 
 import (
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/game"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/types/events"
 	"golang.org/x/net/context"
-	"time"
 )
 
 type GameServiceMock struct {

--- a/src/pkg/observability/logger.go
+++ b/src/pkg/observability/logger.go
@@ -7,15 +7,16 @@ package observability
 
 import (
 	"context"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"time"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/log"
 	logsdk "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
-	"log/slog"
-	"net/url"
-	"strconv"
-	"time"
 )
 
 // LoggerProvider defines the interface for managing log collection.

--- a/src/pkg/observability/metrics.go
+++ b/src/pkg/observability/metrics.go
@@ -7,12 +7,13 @@ package observability
 
 import (
 	"context"
+	"net/url"
+	"time"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/metric"
 	metricsdk "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	"net/url"
-	"time"
 )
 
 // MeterProvider defines the interface for managing metrics collection.

--- a/src/pkg/observability/observability.go
+++ b/src/pkg/observability/observability.go
@@ -6,9 +6,10 @@
 package observability
 
 import (
+	"log/slog"
+
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"log/slog"
 )
 
 // Observability manages all observability abilities within an application.

--- a/src/pkg/observability/provider.go
+++ b/src/pkg/observability/provider.go
@@ -7,12 +7,13 @@ package observability
 
 import (
 	"context"
+	"log/slog"
+	"time"
+
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/trace"
-	"log/slog"
-	"time"
 )
 
 // Provider manages the lifecycle and accessibility of the observability
@@ -114,7 +115,6 @@ func (provider *Provider) Stack(log, trace, metric string, nextLogger slog.Handl
 
 	return o
 }
-
 
 // NewProvider creates a new Provider instance with all observability
 // components configured based on the provided configuration.

--- a/src/pkg/observability/resource.go
+++ b/src/pkg/observability/resource.go
@@ -7,12 +7,13 @@ package observability
 
 import (
 	"fmt"
+	"log/slog"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	"log/slog"
 )
 
 func SetLogger(handler slog.Handler) {

--- a/src/pkg/observability/span.go
+++ b/src/pkg/observability/span.go
@@ -8,6 +8,7 @@ package observability
 import (
 	"context"
 	"encoding/hex"
+
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"

--- a/src/pkg/observability/tracing.go
+++ b/src/pkg/observability/tracing.go
@@ -7,12 +7,13 @@ package observability
 
 import (
 	"context"
+	"net/url"
+	"time"
+
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
-	"net/url"
-	"time"
 )
 
 // TracerProvider defines the interface for managing trace collection
@@ -23,7 +24,6 @@ type TracerProvider interface {
 	Shutdown(ctx context.Context) error
 	Tracer(name string, options ...trace.TracerOption) trace.Tracer
 }
-
 
 // NewTracingProvider creates a new TracerProvider configured with the provided
 // resource and configuration options.

--- a/src/pkg/process/process.go
+++ b/src/pkg/process/process.go
@@ -8,13 +8,14 @@ package process
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 // Result represents the outcome of a process execution.

--- a/src/pkg/process/unix.go
+++ b/src/pkg/process/unix.go
@@ -1,9 +1,9 @@
+//go:build unix
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-//go:build unix
 
 package process
 

--- a/src/pkg/process/windows.go
+++ b/src/pkg/process/windows.go
@@ -1,9 +1,9 @@
+//go:build windows
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-//go:build windows
 
 package process
 

--- a/src/pkg/process/windows_test.go
+++ b/src/pkg/process/windows_test.go
@@ -6,9 +6,10 @@
 package process
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetByIdRedisCacheHit(t *testing.T) {

--- a/src/pkg/runner/mocks.go
+++ b/src/pkg/runner/mocks.go
@@ -7,13 +7,14 @@ package runner
 
 import (
 	"bytes"
+	"log/slog"
+	"time"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/internal/mocks"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/google/uuid"
 	"golang.org/x/net/context"
-	"log/slog"
-	"time"
 )
 
 type RunnerMockHelper struct {

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -7,12 +7,13 @@ package runner
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/constants"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/manager"
 	"github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper/pkg/observability"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"log/slog"
 )
 
 type Services struct {

--- a/src/pkg/runner/runner_test.go
+++ b/src/pkg/runner/runner_test.go
@@ -7,8 +7,9 @@ package runner
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Runner_Run_HappyPath(t *testing.T) {

--- a/src/pkg/types/events/hosting-start.go
+++ b/src/pkg/types/events/hosting-start.go
@@ -12,6 +12,7 @@ import (
 // HostingStart represents the initialization configuration for a game server instance.
 type HostingStart struct {
 	CliArgs                   []config.CliArg
+	ContainerPort             int
 	DNSName                   string
 	FleetId                   string
 	GamePort                  int

--- a/src/template/template-managed-containers-config.yaml
+++ b/src/template/template-managed-containers-config.yaml
@@ -11,5 +11,5 @@ game-server-details:
   executable-file-path: ./MyGame/my-server-executable
   game-server-args:
     - arg: "--port"
-      val: "{{.GamePort}}"
+      val: "{{.ContainerPort}}"
       pos: 0


### PR DESCRIPTION
- Upgraded the Server SDK to version 5.3.0
- Fixed an issue in the container fleet template that caused the game server to listen on the incorrect port; the game server now correctly listens on the configured container-internal port

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.