### PR TITLE
Add UDP ports to create-container-group-definition in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ aws gamelift create-container-group-definition \
 --operating-system AMAZON_LINUX_2023 \
 --total-memory-limit-mebibytes 1024 \
 --total-vcpu-limit 1 \
---game-server-container-definition "{\"ContainerName\": \"GameServer\", \"ImageUri\": \"${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/gamelift-sdk-wrapper-sample:latest\", \"PortConfiguration\": {\"ContainerPortRanges\": [{\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"TCP\"}]}, \"ServerSdkVersion\": \"5.4.0\"}"
+--game-server-container-definition "{\"ContainerName\": \"GameServer\", \"ImageUri\": \"${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/gamelift-sdk-wrapper-sample:latest\", \"PortConfiguration\": {\"ContainerPortRanges\": [{\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"TCP\"}, {\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"UDP\"}]}, \"ServerSdkVersion\": \"5.4.0\"}"
 ```
 Wait for it to be READY before proceeding. You can check its status using [AWS console](https://console.aws.amazon.com/gamelift/container-groups) or [DescribeContainerGroupDefinition API](https://docs.aws.amazon.com/gamelift/latest/apireference/API_DescribeContainerGroupDefinition.html)
 ### Create Container Fleet Role


### PR DESCRIPTION
### Issue #, if available:
The create-container-group-definition in README does not include any UDP ports, so any game server executable would not be able to communicate with a game client over UDP.


### Description of Changes

Add UDP ports to create-container-group-definition in README


### Description of Testing and Validations of Changes

This command succeeded:
```
aws gamelift create-container-group-definition \
--region us-west-2 \
--name "sample" \
--operating-system AMAZON_LINUX_2023 \
--total-memory-limit-mebibytes 1024 \
--total-vcpu-limit 1 \
--game-server-container-definition "{\"ContainerName\": \"GameServer\", \"ImageUri\": \"${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/sample:latest\", \"PortConfiguration\": {\"ContainerPortRanges\": [{\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"TCP\"}, {\"FromPort\": 37016, \"ToPort\": 37020, \"Protocol\": \"UDP\"}]}, \"ServerSdkVersion\": \"5.4.0\"}"
```

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*